### PR TITLE
updated eventserver --> 3.0.3

### DIFF
--- a/src/terraform/instance/task-definitions.tf
+++ b/src/terraform/instance/task-definitions.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_task_definition" "api" {
   container_definitions = jsonencode([
     {
       name  = "eventserver-container"
-      image = "snowclone/eventserver:3.0.1"
+      image = "snowclone/eventserver:3.0.3"
       portMappings = [
         {
           name          = "eventserver-port-8080"


### PR DESCRIPTION
-- new eventserver sends keepalive message every 30 seconds
-- silenced warning from EventEmitter when more than 10 listeners are attached to same event